### PR TITLE
增加对C++的支持，修改Android.mk疑似错误。

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -23,8 +23,8 @@ else ifeq ($(TARGET_ARCH), arm64)
 	ZZ_SRC += $(wildcard $(LOCAL_PATH)/src/platforms/arch-arm64/*.c) \
 			$(wildcard $(LOCAL_PATH)/src/platforms/backend-arm64/*.c)
 else ifeq ($(TARGET_ARCH), x86)
-	ZZ_SRC += $(wildcard $(LOCAL_PATH)/src/platforms/arch-arm64/*.c) \
-			$(wildcard $(LOCAL_PATH)/src/platforms/backend-arm64/*.c)
+	ZZ_SRC += $(wildcard $(LOCAL_PATH)/src/platforms/arch-x86/*.c) \
+			$(wildcard $(LOCAL_PATH)/src/platforms/backend-x86/*.c)
 endif
 
 LOCAL_MODULE := hookzz

--- a/include/hookzz.h
+++ b/include/hookzz.h
@@ -17,6 +17,9 @@
 #ifndef hook_zz_h
 #define hook_zz_h
 
+#ifdef __cplusplus
+extern "C" {
+#endif //__cplusplus
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -179,4 +182,7 @@ ZZSTATUS ZzSolidifyHook(zpointer target_fileoff, zpointer replace_call_ptr, zpoi
                         POSTCALL post_call_ptr);
 #endif
 
+#ifdef __cplusplus
+}
+#endif //__cplusplus
 #endif


### PR DESCRIPTION
1.由于在c++上编译发现有找不到方法的错误，在头文件中增加` extern "C"`描述，使C++能正确调用。
2.Android.mk编译脚本中出现编译链为X86的时候编译的是arm64的c文件，不知道是否手抖？